### PR TITLE
Return exit code in Docker e2e tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,3 @@ ENV PATH /google-cloud-sdk/bin:$PATH
 COPY . /tmp/kube-jenkins-imager
 RUN cp /tmp/kube-jenkins-imager/ssl_secrets.template.yaml /tmp/kube-jenkins-imager/ssl_secrets.yaml
 RUN cp /tmp/kube-jenkins-imager/test/e2e.sh /tmp/kube-jenkins-imager/e2e.sh
-WORKDIR /tmp/kube-jenkins-imager
-
-ENTRYPOINT ["./e2e.sh"]

--- a/flow.groovy
+++ b/flow.groovy
@@ -1,7 +1,7 @@
 node('docker') {
-  def hash = git url: "${GIT_URL}"
-  def app = docker.build "${hash}"
-  app.withRun("-e 'LEADER_IMAGE=${LEADER_IMAGE}' -e 'PACKER_IMAGE=${PACKER_IMAGE}' -e 'PROXY_IMAGE=${PROXY_IMAGE}'") {c ->
-    sh "docker logs -f ${c.id}"
+  checkout scm
+  def app = docker.build "$env.BRANCH_NAME-$env.BUILD_NUMBER"
+  app.inside("-e 'LEADER_IMAGE=${LEADER_IMAGE}' -e 'PACKER_IMAGE=${PACKER_IMAGE}' -e 'PROXY_IMAGE=${PROXY_IMAGE}'") {
+    sh "./test/e2e.sh"
   }
 }


### PR DESCRIPTION
This change uses docker.inside rather than docker.withRun in the Workflow groovy script to allow Docker to surface its exit code to Jenkins.

To enable this, you must configure Jenkins (https://JENKINS_ADDRESS/configure) and add a **Host Path Volume" that mounts `/root/workspace` to `/root/workspace`.
