### PR TITLE
Use updated Jenkins solution which simplifies things considerably

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,6 @@ RUN apt-get install -y -qq --no-install-recommends wget unzip python php5-mysql 
   && wget https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.zip && unzip google-cloud-sdk.zip && rm google-cloud-sdk.zip \
   && /google-cloud-sdk/install.sh --usage-reporting=true --path-update=true --bash-completion=true --rc-path=/.bashrc --disable-installation-options \
   && /google-cloud-sdk/bin/gcloud --quiet config set component_manager/disable_update_check true
-RUN /google-cloud-sdk/bin/gcloud components update kubectl beta --quiet
 ENV PATH /google-cloud-sdk/bin:$PATH
 
 COPY . /tmp/kube-jenkins-imager

--- a/cluster_down.sh
+++ b/cluster_down.sh
@@ -14,15 +14,5 @@
 CLUSTER_NAME=${1-imager}
 ZONE=us-central1-f
 
-# Delete services
-kubectl delete -f service_jenkins.yaml
-kubectl delete -f service_ssl_proxy.yaml
-
-# Delete firewall rules
-gcloud compute firewall-rules delete --quiet ${CLUSTER_NAME}-jenkins-swarm-internal
-gcloud compute firewall-rules delete --quiet ${CLUSTER_NAME}-jenkins-web-public
-
 # Delete cluster
 gcloud container clusters delete --quiet ${CLUSTER_NAME} --zone ${ZONE}
-
-

--- a/cluster_up.sh
+++ b/cluster_up.sh
@@ -21,69 +21,43 @@ CLUSTER_NAME=${1-imager}
 NUM_NODES=3
 MACHINE_TYPE=n1-standard-1
 ZONE=us-central1-f
-TEMPKEY=false
 
 # Source the config
 . images.cfg
 
-# Set up SSH for GCEt stat
-if [ -f "~/.ssh/google_compute_engine" ]
-then
-    TEMPKEY=true
-    echo -n "* Generating a temporary SSH key pair..."
-    ssh-keygen -f ~/.ssh/google_compute_engine -t rsa -N '' || error_exit "Error creating key pair"
-    echo "done."
-fi
-
-echo -n "* Creating Google Container Engine cluster \"${CLUSTER_NAME}\"..."
+echo "* Creating Google Container Engine cluster \"${CLUSTER_NAME}\"..."
 # Create cluster
 gcloud container clusters create ${CLUSTER_NAME} \
   --num-nodes ${NUM_NODES} \
   --machine-type ${MACHINE_TYPE} \
   --scopes "https://www.googleapis.com/auth/projecthosting,https://www.googleapis.com/auth/devstorage.full_control,https://www.googleapis.com/auth/monitoring,https://www.googleapis.com/auth/logging.write,https://www.googleapis.com/auth/compute,https://www.googleapis.com/auth/cloud-platform" \
-  --zone ${ZONE} >/dev/null || error_exit "Error creating Google Container Engine cluster"
-echo "done."
-
-if [ "$TEMPKEY" = "true" ]
-then
-  echo -n "* Deleting temporary SSH key pair..."
-  rm ~/.ssh/google_compute_engine*
-  echo "done."
-fi
-
-echo -n "* Creating firewall rules..."
-# Allow kubernetes nodes to communicate between eachother on TCP 50000 and 8080
-gcloud compute firewall-rules create ${CLUSTER_NAME}-jenkins-swarm-internal --allow TCP:50000,TCP:8080 --source-tags gke-${CLUSTER_NAME}-node --target-tags gke-${CLUSTER_NAME}-node &>/dev/null || error_exit "Error creating internal firewall rule"
-# Allow public access to TCP 80 and 443
-gcloud compute firewall-rules create ${CLUSTER_NAME}-jenkins-web-public --allow TCP:80,TCP:443 --source-ranges 0.0.0.0/0 --target-tags gke-${CLUSTER_NAME}-node &>/dev/null || error_exit "Error creating public firewall rule"
+  --zone ${ZONE} || error_exit "Error creating Google Container Engine cluster"
 echo "done."
 
 # Make kubectl use new clusterc
-echo -n "* Configuring kubectl to use new gke_$(gcloud config list | grep project | cut -f 3 -d' ')_${ZONE}_${CLUSTER_NAME} cluster..."
-kubectl config use-context gke_$(gcloud config list | grep project | cut -f 3 -d' ')_${ZONE}_${CLUSTER_NAME} >/dev/null || error_exit "Error configuring kubectl"
+echo "* Configuring kubectl to use ${CLUSTER_NAME} cluster..."
+gcloud container clusters get-credentials ${CLUSTER_NAME}
 echo "done."
 
-# Wait for API server to become avilable
-for i in {1..5}; do kubectl get pods &>/dev/null && break || sleep 2; done
+echo "Getting Jenkins artifacts"
+git clone https://github.com/GoogleCloudPlatform/continuous-deployment-on-kubernetes
 
-echo -n "* Tagging nodes..."
-gcloud compute instances list \
-  -r "^gke-${CLUSTER_NAME}.*node.*$" \
-  | tail -n +2 \
-  | cut -f1 -d' ' \
-  | xargs -L 1 -I '{}' gcloud compute instances add-tags {} --zone ${ZONE} --tags gke-${CLUSTER_NAME}-node &>/dev/null || error_exit "Error adding tags to nodes"
+echo "Deploying Jenkins to Google Container Engine..."
+pushd continuous-deployment-on-kubernetes
+echo "* Creating Jenkins home image"
+gcloud compute images create jenkins-home-image --source-uri https://storage.googleapis.com/solutions-public-assets/jenkins-cd/jenkins-home.tar.gz
+echo "* Creating Jenkins home disk"
+gcloud compute disks create jenkins-home --image jenkins-home-image --zone ${ZONE}
+PASSWORD=`openssl rand -base64 15`; echo "Your Jenkins password is $PASSWORD"; sed -i.bak s#CHANGE_ME#$PASSWORD# jenkins/k8s/options
+kubectl create ns jenkins
+kubectl create secret generic jenkins --from-file=jenkins/k8s/options --namespace=jenkins
+kubectl apply -f jenkins/k8s/
+openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout /tmp/tls.key -out /tmp/tls.crt -subj "/CN=jenkins/O=jenkins"
+kubectl create secret generic tls --from-file=/tmp/tls.crt --from-file=/tmp/tls.key --namespace jenkins
+kubectl apply -f jenkins/k8s/lb/ingress.yaml
+popd
 echo "done."
 
-# Deploy secrets, replication controllers, and services
-echo -n "* Deploying services, controllers, and secrets to Google Container Engine..."
-kubectl create -f ssl_secrets.yaml >/dev/null || error_exit "Error deploying ssl_secrets.yaml" 
-kubectl create -f service_ssl_proxy.yaml >/dev/null || error_exit "Error deploying service_ssl_proxy.yaml"
-kubectl create -f service_jenkins.yaml >/dev/null || error_exit "Error deploying service_jenkins.yaml"
-
-# Replace {{image}} tokens with image URls sourced from images.cfg
-cat ssl_proxy.yaml | sed "s@image:.*@image: $PROXY_IMAGE@" | kubectl create -f - >/dev/null || error_exit "Error deploying ssl_proxy.yaml"
-cat leader.yaml | sed "s@image:.*@image: $LEADER_IMAGE@" | kubectl create -f - >/dev/null || error_exit "Error deploying leader.yaml"
-cat agent.yaml | sed "s@image:.*@image: $PACKER_IMAGE@" | kubectl create -f - >/dev/null || error_exit "Error deploying agent.yaml"
-echo "done."
-
-echo "All resources deployed. Run 'echo http://\$(kubectl describe service/nginx-ssl-proxy 2>/dev/null | grep 'LoadBalancer\ Ingress' | cut -f2)' to find your server's address, then give it a few minutes before trying to connect."
+echo "All resources deployed."
+echo "Run 'kubectl get ingress jenkins --namespace jenkins -o \"jsonpath={.status.loadBalancer.ingress[0].ip}\";echo' to find your server's address, then give it a few minutes before trying to connect."
+echo "Login with user: jenkins and password ${PASSWORD}"


### PR DESCRIPTION
This removes the need for having long running Jenkins agents and makes it easier to use GKE autoscaling with this solution. 

Jenkins install instructions are leveraged from [Jenkins on Container Engine Tutorial](https://cloud.google.com/solutions/jenkins-on-container-engine-tutorial).
